### PR TITLE
Fixed long polling config

### DIFF
--- a/get-started/content/quick-start/service-task.md
+++ b/get-started/content/quick-start/service-task.md
@@ -156,6 +156,7 @@ public class ChargeCardWorker {
   public static void main(String[] args) {
     ExternalTaskClient client = ExternalTaskClient.create()
         .baseUrl("http://localhost:8080/engine-rest")
+	.asyncResponseTimeout(10000) // long polling timeout
         .build();
 
     // subscribe to an external task topic as specified in the process
@@ -229,7 +230,8 @@ const { Client, logger } = require('camunda-external-task-client-js');
 // configuration for the Client:
 //  - 'baseUrl': url to the Process Engine
 //  - 'logger': utility to automatically log important events
-const config = { baseUrl: 'http://localhost:8080/engine-rest', use: logger };
+//  - 'asyncResponseTimeout': long polling timeout (then a new request will be issued)
+const config = { baseUrl: 'http://localhost:8080/engine-rest', use: logger, asyncResponseTimeout: 10000 };
 
 // create a Client instance with custom configuration
 const client = new Client(config);


### PR DESCRIPTION
Added asyncResponseTimeout parameter to enable long polling correctly - otherwise it is NOT used at all (but stated in the docs). 
Actually we should definitely go for long polling in the get started IMHO.