### PR TITLE
Fixed npm init command

### DIFF
--- a/get-started/content/quick-start/service-task.md
+++ b/get-started/content/quick-start/service-task.md
@@ -205,7 +205,7 @@ Make sure you have the following tools installed:
 ```sh
 mkdir charge-card-worker
 cd ./charge-card-worker
-npm init charge-card-worker -y
+npm init -y
 ```
 
 ### Add Camunda External Task Client JS library


### PR DESCRIPTION
The current command is not working and produces error - this version works correctly. Probably some JS pro should have a quick look if the change is OK