### PR TITLE
CAM-11938: announce end of support for IE 11

### DIFF
--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -29,6 +29,7 @@ __Changes in Supported Environments:__
 * Support for PostgreSQL 12.2
 * Support for Wildfly Application Server 19.0
 * End of Support for Oracle WebLogic Server 12R1
+* End of Support for Internet Explorer 11
 * The [Javascript External Task Client](https://github.com/camunda/camunda-external-task-client-js/) (version 2.0.0) requires NodeJS 10 or higher. It cannot be used with NodeJS 8 anymore.
 
 

--- a/get-started/content/cmmn11/install.md
+++ b/get-started/content/cmmn11/install.md
@@ -21,7 +21,7 @@ Make sure you have the following set of tools installed:
 
 * Java JDK 1.7+,
 * Apache Maven (optional, if not installed you can use embedded Maven inside Eclipse.)
-* A modern web browser (recent Firefox, Chrome, Microsoft Edge or Internet Explorer 11 will work fine)
+* A modern web browser (recent Firefox, Chrome or Microsoft Edge will work fine)
 * Eclipse integrated development environment (IDE)
 
 

--- a/get-started/content/dmn11/install.md
+++ b/get-started/content/dmn11/install.md
@@ -21,7 +21,7 @@ Make sure you have the following set of tools installed:
 
 * Java JDK 1.7+,
 * Apache Maven (optional, if not installed you can use embedded Maven inside Eclipse.)
-* A modern web browser (recent Firefox, Chrome, Microsoft Edge or Internet Explorer 11 will work fine)
+* A modern web browser (recent Firefox, Chrome or Microsoft Edge will work fine)
 * Eclipse integrated development environment (IDE)
 
 

--- a/get-started/content/java-process-app/install.md
+++ b/get-started/content/java-process-app/install.md
@@ -21,7 +21,7 @@ Make sure you have the following set of tools installed:
 
 * Java JDK 1.7+,
 * Apache Maven (optional, if not installed you can use embedded Maven inside Eclipse.)
-* A modern web browser (recent Firefox, Chrome, Microsoft Edge or Internet Explorer 11 will work fine)
+* A modern web browser (recent Firefox, Chrome or Microsoft Edge will work fine)
 * Eclipse integrated development environment (IDE)
 
 

--- a/get-started/content/javaee7/install.md
+++ b/get-started/content/javaee7/install.md
@@ -20,7 +20,7 @@ Make sure you have the following set of tools installed:
 
 * Java JDK 1.8+
 * Apache Maven (optional, if not installed you can use embedded Maven inside Eclipse.)
-* A modern web browser (recent Firefox, Chrome, Internet Explorer 11, or Microsoft Edge will work fine)
+* A modern web browser (recent Firefox, Chrome or Microsoft Edge will work fine)
 * Eclipse integrated development environment (IDE)
 
 # Install Camunda BPM platform


### PR DESCRIPTION
- also removes IE mentions from getting started guides

related to CAM-11938