### PR TITLE
docs(get-started+security): Fix mistakes in the documentation

### DIFF
--- a/get-started/content/dmn/model.md
+++ b/get-started/content/dmn/model.md
@@ -96,7 +96,7 @@ When you are done, save your changes by clicking *File > Save File As..*. In the
 
 Return to Eclipse. Right-click the project folder and click *Refresh*. This synchronizes the new DMN file with Eclipse.
 
-For Eclipse to automatically sychronize the workspace with the filesystem, consider [configuring auto-sync in eclipse][auto-sync].
+For Eclipse to automatically synchronize the workspace with the filesystem, consider [configuring auto-sync in eclipse][auto-sync].
 
 {{< get-tag repo="camunda-get-started-dmn" tag="Step-3" >}}
 

--- a/get-started/content/java-process-app/forms.md
+++ b/get-started/content/java-process-app/forms.md
@@ -38,7 +38,7 @@ Go back to Eclipse and add a folder named `src/main/webapp/forms`. Inside this f
 </form>
 ```
 
-Open the process with the modeler. Click on the start event. In the properties view, click on the `Forms` tab and insert `embedded:app:forms/request-loan.html` into the `Form Key` property field. This means that we want to use an `embedded` form inside the Tasklist and that the form is loaded from the `app`lication. Save the diagram and refresh the Eclipse project.
+Open the process with the modeler. Click on the start event. In the properties view, click on the `Forms` tab and insert `embedded:app:forms/request-loan.html` into the `Form Key` property field. This means that we want to use an `embedded` form inside the Tasklist and that the form is loaded from the application. Save the diagram and refresh the Eclipse project.
 
 {{< img src="../img/modeler-start-form.png" >}}
 

--- a/get-started/content/javaee7/start-form.md
+++ b/get-started/content/javaee7/start-form.md
@@ -85,7 +85,7 @@ When the form is submitted, the `camundaTaskForm.completeProcessInstanceForm()` 
 
 {{< img src="../img/pizza-order-process-start-form.png" >}}
 
-Open the process with Camunda Modeler. Click on the start event. In the properties view, set the `Form Key` property to `app:placeorder.jsf`. This means that we want to use an external JSF form and that the form is loaded from the `app`lication.
+Open the process with Camunda Modeler. Click on the start event. In the properties view, set the `Form Key` property to `app:placeorder.jsf`. This means that we want to use an external JSF form and that the form is loaded from the application.
 
 When you are done, save all resources, refresh the Eclipse project, perform a Maven build, and redeploy the process application.
 

--- a/get-started/content/javaee7/task-form.md
+++ b/get-started/content/javaee7/task-form.md
@@ -165,7 +165,7 @@ On form submit, the `approveOrderController.submitForm()` method calls the EJB `
 
 {{< img src="../img/pizza-order-process-task-form.png" >}}
 
-Open the process with the modeler. Click on the *Approve Order* user task. In the properties view, set the `Form Key` property to `app:approveorder.jsf`. This means that we want to use an external JSF form and that the form is loaded from the `app`lication.
+Open the process with the modeler. Click on the *Approve Order* user task. In the properties view, set the `Form Key` property to `app:approveorder.jsf`. This means that we want to use an external JSF form and that the form is loaded from the application.
 
 
 # Configure the Conditional Sequence Flows in the Process

--- a/security/content/security-policy.md
+++ b/security/content/security-policy.md
@@ -56,7 +56,7 @@ New software developers are being introduced to our security policy and best pra
 
 ## Reporting Security Issues and Vulnerabilities
 
-Security vulnerabilities can be reported via the Camunda JIRA issue tracker. Find details in the [Report a Vulnerability Guide]({{< ref "/report-vulnerability.md" >}}). Reported vulnerabilities, associated documentation and the identity of reporters are treated confidentially thoughout the entire process.
+Security vulnerabilities can be reported via the Camunda JIRA issue tracker. Find details in the [Report a Vulnerability Guide]({{< ref "/report-vulnerability.md" >}}). Reported vulnerabilities, associated documentation and the identity of reporters are treated confidentially throughout the entire process.
 
 Vulnerabilities discovered by our enterprise customers are treated as bugs and the agreed SLAs apply.
 


### PR DESCRIPTION
Resolved typos in the documentation and removed inappropriate markdowns of application in guides