### PR TITLE
chore(get-started): bump versions in JEE guide

### DIFF
--- a/get-started/content/javaee7/install.md
+++ b/get-started/content/javaee7/install.md
@@ -25,7 +25,7 @@ Make sure you have the following set of tools installed:
 
 # Install Camunda Platform
 
-First, download a distribution of the Camunda Platform. You can choose from different application servers. In this tutorial, we will use the WildFly 20 based distribution. Download it from [the download page](https://downloads.camunda.cloud/release/camunda-bpm/wildfly/).
+First, download a distribution of the Camunda Platform. You can choose from different application servers. In this tutorial, we will use a WildFly-based distribution. Download it from [the download page](https://downloads.camunda.cloud/release/camunda-bpm/wildfly/).
 
 After having downloaded the distribution, unpack it inside a directory of your choice. We will call that directory
 `$CAMUNDA_HOME`.

--- a/get-started/content/javaee7/project-setup.md
+++ b/get-started/content/javaee7/project-setup.md
@@ -64,7 +64,7 @@ The next step consists of setting up the Maven dependencies for your new process
   <packaging>war</packaging>
 
   <properties>
-    <camunda.version>7.14.0</camunda.version>
+    <camunda.version>7.15.0</camunda.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>


### PR DESCRIPTION
* removes the WildFly version as this does always create work and
  does not provide much additional help for the guide

related to CAM-13216