### PR TITLE
chore(redirect): redirect to current version optimize start page

### DIFF
--- a/config/live/.htaccess
+++ b/config/live/.htaccess
@@ -67,6 +67,12 @@ RewriteCond %{DOCUMENT_ROOT}/optimize/%1 !-d
 RewriteCond %{DOCUMENT_ROOT}/optimize/latest%2 -d
 RewriteRule ^optimize/[^/]+(/[^/]+(?:/.*))? /optimize/latest$1 [R=307,L]
 
+# Redirect to selected optimize version starting page if site is unavailable
+RewriteCond %{REQUEST_URI} ^/optimize/((?!latest/?)[^/]+)(.*)
+RewriteCond %{DOCUMENT_ROOT}/optimize/%1%2 !-d
+RewriteCond %{DOCUMENT_ROOT}/optimize/%1%2 !-f
+RewriteCond %{DOCUMENT_ROOT}/optimize/%1 -d
+RewriteRule ^optimize/(.*) /optimize/%1 [R=307,L]
 
 # Cawemo without version
 RewriteRule ^cawemo/?$ /cawemo/latest/ [R=301,L]


### PR DESCRIPTION
relates to #OPT-5149

Tested on stage by previously merging #164.
Sample case, go to http://stage.docs.camunda.org/optimize/1.5/user-guide/frequency/
and switch to Version 3.3.