### PR TITLE
chore(redirect): redirect to current Cawemo version start page

### DIFF
--- a/config/stage/.htaccess
+++ b/config/stage/.htaccess
@@ -88,6 +88,12 @@ RewriteCond %{DOCUMENT_ROOT}/cawemo/%1 !-d
 RewriteCond %{DOCUMENT_ROOT}/cawemo/latest%2 -d
 RewriteRule ^cawemo/[^/]+(/[^/]+(?:/.*))? /cawemo/latest$1 [R=307,L]
 
+# Redirect to selected Cawemo version starting page if site is unavailable
+RewriteCond %{REQUEST_URI} ^/cawemo/((?!latest/?)[^/]+)(.*)
+RewriteCond %{DOCUMENT_ROOT}/cawemo/%1%2 !-d
+RewriteCond %{DOCUMENT_ROOT}/cawemo/%1%2 !-f
+RewriteCond %{DOCUMENT_ROOT}/cawemo/%1 -d
+RewriteRule ^cawemo/(.*) /cawemo/%1 [R=307,L]
 
 # Enterprise
 RewriteRule ^enterprise/previous-downloads.html$ /enterprise/download/ [R=301,L]


### PR DESCRIPTION
Implements the fix done in https://github.com/camunda/camunda-docs-static/pull/165 for Cawemo - for testing purposes only on stage, a follow-up PR for prod will be opened once it works.

(see https://github.com/camunda/cawemo/issues/8000)