### PR TITLE
chore(redirect): include latest version in invalid path handling rule

### DIFF
--- a/config/live/.htaccess
+++ b/config/live/.htaccess
@@ -68,7 +68,7 @@ RewriteCond %{DOCUMENT_ROOT}/optimize/latest%2 -d
 RewriteRule ^optimize/[^/]+(/[^/]+(?:/.*))? /optimize/latest$1 [R=307,L]
 
 # Redirect to selected optimize version starting page if site is unavailable
-RewriteCond %{REQUEST_URI} ^/optimize/((?!latest/?)[^/]+)(.*)
+RewriteCond %{REQUEST_URI} ^/optimize/([^/]+)(.*)
 RewriteCond %{DOCUMENT_ROOT}/optimize/%1%2 !-d
 RewriteCond %{DOCUMENT_ROOT}/optimize/%1%2 !-f
 RewriteCond %{DOCUMENT_ROOT}/optimize/%1 -d


### PR DESCRIPTION
relates to #OPT-5149

Thanks to @wollefitz for noticing this edge-case!

Testable on stage with  https://github.com/camunda/camunda-docs-static/commit/4f52e8e0bf4ce0d4bce5fc97f87fda9c0fcd2500