### PR TITLE
chore(redirect): redirect to current Cawemo version start page if site not found

### DIFF
--- a/config/live/.htaccess
+++ b/config/live/.htaccess
@@ -93,6 +93,12 @@ RewriteCond %{DOCUMENT_ROOT}/cawemo/%1 !-d
 RewriteCond %{DOCUMENT_ROOT}/cawemo/latest%2 -d
 RewriteRule ^cawemo/[^/]+(/[^/]+(?:/.*))? /cawemo/latest$1 [R=307,L]
 
+# Redirect to selected Cawemo version starting page if site is unavailable
+RewriteCond %{REQUEST_URI} ^/cawemo/([^/]+)(.*)
+RewriteCond %{DOCUMENT_ROOT}/cawemo/%1%2 !-d
+RewriteCond %{DOCUMENT_ROOT}/cawemo/%1%2 !-f
+RewriteCond %{DOCUMENT_ROOT}/cawemo/%1 -d
+RewriteRule ^cawemo/(.*) /cawemo/%1 [R=307,L]
 
 # Enterprise
 RewriteRule ^enterprise/previous-downloads.html$ /enterprise/download/ [R=301,L]

--- a/config/stage/.htaccess
+++ b/config/stage/.htaccess
@@ -89,7 +89,7 @@ RewriteCond %{DOCUMENT_ROOT}/cawemo/latest%2 -d
 RewriteRule ^cawemo/[^/]+(/[^/]+(?:/.*))? /cawemo/latest$1 [R=307,L]
 
 # Redirect to selected Cawemo version starting page if site is unavailable
-RewriteCond %{REQUEST_URI} ^/cawemo/((?!latest/?)[^/]+)(.*)
+RewriteCond %{REQUEST_URI} ^/cawemo/([^/]+)(.*)
 RewriteCond %{DOCUMENT_ROOT}/cawemo/%1%2 !-d
 RewriteCond %{DOCUMENT_ROOT}/cawemo/%1%2 !-f
 RewriteCond %{DOCUMENT_ROOT}/cawemo/%1 -d


### PR DESCRIPTION
Implements the fix done in #167, #165 and #164 for Cawemo.

For a simple test case go to http://stage.docs.camunda.org/cawemo/1.6/foo

(see https://github.com/camunda/cawemo/issues/8000)