### PR TITLE
CAM-13585: fix(guide): adjust quick start web apps links

### DIFF
--- a/get-started/content/quick-start/decision-automation.md
+++ b/get-started/content/quick-start/decision-automation.md
@@ -55,14 +55,14 @@ To deploy the Decision Table, click on the Deploy button in the Camunda Modeler,
 {{< img src="../img/modeler-dmn6.png" >}}
 
 # Verify the Deployment with Cockpit
-Now, use Cockpit to see if the decision table was successfully deployed. Go to [http://localhost:8080/camunda/app/cockpit](http://localhost:8080/camunda/app/cockpit). Log in with the credentials *demo / demo*. Navigate to the "Decisions" section. Your decision table *Approve Payment* should be listed as deployed decision definition.
+Now, use Cockpit to see if the decision table was successfully deployed. Go to [http://localhost:8080/camunda/app/cockpit/](http://localhost:8080/camunda/app/cockpit/). Log in with the credentials *demo / demo*. Navigate to the "Decisions" section. Your decision table *Approve Payment* should be listed as deployed decision definition.
 
 {{< img src="../img/cockpit-approve-payment.png" >}}
 
 # Inspect using Cockpit and Tasklist
 
 Next, use Tasklist to start two new Process Instances and verify that depending on your input, the Process Instance will be routed differently.
-To do so, go to [http://localhost:8080/camunda/app/tasklist](http://localhost:8080/camunda/app/tasklist). Log in with *demo / demo*.
+To do so, go to [http://localhost:8080/camunda/app/tasklist/](http://localhost:8080/camunda/app/tasklist/). Log in with *demo / demo*.
 
 Click on the {{< glyphicon name="list-alt" text=" Start process" >}} button to start a process instance and choose the `Payment` process.
 Use the generic form to add the variables as follows:
@@ -75,7 +75,7 @@ Use the generic form to add the variables as follows:
 {{< img src="../img/tasklist-dmn2.png" >}}
 
 You'll see that depending on the input, the worker will either charge or not charge the credit card.
-You can also verify that the DMN tables were evaluated by using Camunda Cockpit. Go to [http://localhost:8080/camunda/app/cockpit](http://localhost:8080/camunda/app/cockpit). Log in with the credentials *demo / demo*. Navigate to the "Decisions" section and click on Approve Payment. Check the different Decision Instances that were evaluated by clicking on the ID in the table.
+You can also verify that the DMN tables were evaluated by using Camunda Cockpit. Go to [http://localhost:8080/camunda/app/cockpit/](http://localhost:8080/camunda/app/cockpit/). Log in with the credentials *demo / demo*. Navigate to the "Decisions" section and click on Approve Payment. Check the different Decision Instances that were evaluated by clicking on the ID in the table.
 
 A single DMN table that was executed could look like this in Camunda Cockpit:
 {{< img src="../img/cockpit-dmn-table.png" >}}

--- a/get-started/content/quick-start/deploy.md
+++ b/get-started/content/quick-start/deploy.md
@@ -27,7 +27,7 @@ More details regarding the deployment from Camunda Modeler you can find [here](h
 
 # Verify the Deployment with Cockpit
 
-Next, use Cockpit to see if the process was successfully deployed. Go to [http://localhost:8080/camunda/app/cockpit](http://localhost:8080/camunda/app/cockpit) and log in with the credentials demo / demo. Your process *Payment Retrieval* should be visible on the dashboard.
+Next, use Cockpit to see if the process was successfully deployed. Go to [http://localhost:8080/camunda/app/cockpit/](http://localhost:8080/camunda/app/cockpit/) and log in with the credentials demo / demo. Your process *Payment Retrieval* should be visible on the dashboard.
 
 {{< img src="../img/cockpit-payment-retrieval.png" >}}
 

--- a/get-started/content/quick-start/gateway.md
+++ b/get-started/content/quick-start/gateway.md
@@ -51,7 +51,7 @@ Use the `Deploy` Button in the Camunda Modeler to deploy the updated process to 
 
 # Work on the Task
 
-Go to Tasklist ([http://localhost:8080/camunda/app/tasklist](http://localhost:8080/camunda/app/tasklist)) and log in with the credentials "demo / demo".
+Go to Tasklist ([http://localhost:8080/camunda/app/tasklist/](http://localhost:8080/camunda/app/tasklist/)) and log in with the credentials "demo / demo".
 Click on the {{< glyphicon name="list-alt" text=" Start process" >}} button to start a process instance for the *Payment Retrieval* Process.
 Next, set variables for the process instance using the generic form as we learned in the *User Tasks* section.
 

--- a/get-started/content/quick-start/user-task.md
+++ b/get-started/content/quick-start/user-task.md
@@ -74,7 +74,7 @@ Use the `Deploy` Button in the Camunda Modeler to deploy the updated process to 
 
 # Work on the Task
 
-Go to Tasklist ([http://localhost:8080/camunda/app/tasklist](http://localhost:8080/camunda/app/tasklist)) and log in with the credentials "demo / demo".
+Go to Tasklist ([http://localhost:8080/camunda/app/tasklist/](http://localhost:8080/camunda/app/tasklist/)) and log in with the credentials "demo / demo".
 Click on the {{< glyphicon name="list-alt" text=" Start process" >}} button to start a process instance. This opens a dialog where you can select *Payment Retrieval* from the list. Now you can set variables for the process instance using a generic form.
 
 {{< img src="../img/start-form-generic.png" >}}


### PR DESCRIPTION
* The links to the Camunda web apps in the Quick Start guide need to have a backslash (/) at the end to work correctly.

Related to CAM-13585