### PR TITLE
CAM-13620: docs(security): remove duplicate content with camunda.com/security

### DIFF
--- a/security/content/report-vulnerability.md
+++ b/security/content/report-vulnerability.md
@@ -10,11 +10,4 @@ menu:
 
 ---
 
-In order to report a vulnerability in the Camunda Platform products, please follow these steps:
-
-1. Create an account on the [Camunda JIRA issue tracker](https://app.camunda.com/jira/browse/CAM)
-1. Navigate to the [issue creation screen](https://app.camunda.com/jira/secure/CreateIssue!default.jspa)
-1. Create a JIRA ticket in the **Camunda (CAM) project** of type **Security Report**. With this type, the issue will only be accessible by Camunda staff and you, the reporter.
-1. Please provide as many details as are known to you.
-
-Once reported, Camunda staff will get back to you and treat your report according to our [Security Issue Process]({{< ref "/security-policy.md#security-issue-management" >}})).
+In order to report a vulnerability in the Camunda Platform products, follow the steps outlined on [camunda.com/security](https://camunda.com/security#report-a-vulnerability). 

--- a/security/content/security-policy.md
+++ b/security/content/security-policy.md
@@ -12,82 +12,14 @@ menu:
 
 As a core infrastructure component of our customers, the security of Camunda Platform (also referred to as the 'software') takes top priority and is maintained constantly.
 
+For information on our Camunda Security Policy, see [camunda.com/security](https://camunda.com/security). 
 
-# Information Security Standards
-
-The security of the areas listed in the next section is ensured based on common industry best practises. Thus, the development of the software is being influenced by standards like [OWASP Top 10](https://owasp.org/www-project-top-ten/)), [CVSS](https://www.first.org/cvss/) and others.
-
-# Organizational Aspects of Security
-
-## Roles and Responsibilities
-
-Camunda's organizational structure includes a role dedicated to security. This role is assigned to a senior employee who is
-responsible for the establishment, administration and maintenance of this policy.
-
-## Security in context of the Systems Development Life Cycle ("SDLC")
-Application and System development follows a defined methodology that contains a preliminary review of information security requirements to ensure the following minimum standards.
-
-### Segregation of duties
-Segregation of duties is incorporated into the SDLC so that a single person is unable to introduce security vulnerabilities into the software. The team responsible for software development is separated from the team responsible for the regressions testing and delivery of the software.
-
-### On-Going Software Development
-A formal change management process is used when making changes to the software which includes the following minimum standards:
-
-1. Each code change by one software developer is reviewed and approved by a second software developer;
-2. Changes to the software must not be packaged into the final software artefacts (which are provided for download to the customers) by the same person who does the development; and
-3. A record of all changes to the software exists that identifies:
-  * a brief description of each change that was made;
-  * who made each change;
-  * test cases for future automated regressions testing of this change;
-  * who reviewed each change; and
-  * the date and time when each change was made.
-
-### Review Frequency
-Reviews of any new major or minor release shall be conducted to revalidate the software prior to making it available for download to the Customer.
-
-### Third Party Dependencies
-Third party dependencies contained within the software are constantly being monitored. In case there are newer versions of these dependencies that include security relevant improvements, a plan to incorporate the updated versions is created.
-
-## Onboarding of Employees
-
-New software developers are being introduced to our security policy and best practices during their onboarding process.
-
-# Security Issue Management
-
-## Reporting Security Issues and Vulnerabilities
-
-Security vulnerabilities can be reported via the Camunda JIRA issue tracker. Find details in the [Report a Vulnerability Guide]({{< ref "/report-vulnerability.md" >}}). Reported vulnerabilities, associated documentation and the identity of reporters are treated confidentially throughout the entire process.
-
-Vulnerabilities discovered by our enterprise customers are treated as bugs and the agreed SLAs apply.
-
-## Qualification
-
-Once reported, Camunda proceeds to assess a vulnerability. This includes root cause analysis, as well as understanding the risk (how likely is the vulnerability to be exploited?) and impact (what can an attacker do when exploiting the vulnerability?) of the problem. This assessment is made in close collaboration with the reporter.
-
-## Remediation
-
-Camunda creates a remediation plan to resolve security issues that are identified. Fixes are made available in the form of patch releases (enterprise customers only) and alpha/minor releases (community platform users).
-
-## Announcement
-
-Once a fix release or a practicable workaround is available, Camunda informs its users on the [Security Notices]({{< ref "/notices.md" >}}) page.
-
-# Security Acceptance and Maintenance
-
-## Acceptance
-The software shall not be considered accepted until the security review has been completed and all security issues have been assigned to a remediation plan. The security review is part of the Regression Testing.
-
-## Automatic Regression Testing
-For a release to be accepted, several automated regression tests must be passed. Testing the security relevant aspects of the software is part of this regression test.
-
-## Manual Regression Testing
-For a release to be accepted, a manual regression test must be passed. Testing the security relevant aspects of the software is part of this manual regression test.
 
 ## Penetration Testing
 
 Camunda has contracted an independent, external security advisor to regularly conduct penetration tests of the software. The advisor operates according to industry best practices recommended by the OWASP organization such as the [OWASP Testing Guide](https://www.owasp.org/images/1/19/OTGv4.pdf). The tools used for testing include [Burp Suite](https://portswigger.net/burp) and [DefenseCode Thunderscan](https://www.defensecode.com/thunderscan.php)
 
-Any vulnerabilities detected are handled according to our [process for security issue management](#security-issue-management).
+Any vulnerabilities detected are handled according to our [process for security issue management](https://camunda.com/security#security-issue-management).
 
 Test history:
 
@@ -124,8 +56,3 @@ Test history:
     </td>
   </tr>
 </table>
-
-## Automatic Virus Scans
-
-An automatic virus scan is part of our release process. Its catalogues are up to date and it is used to scan the released distributions our users can download.
-In addition automatic virus scans are being performed on our core infrastructure components.


### PR DESCRIPTION
* Removed Report a Vulnerability steps. Linked to [camunda.com/security](https://camunda.com/security#report-a-vulnerability). 
* Removed Security Policy content, except Penetration Testing section and table. Linked to camunda.com/security and camunda.com/security#security-issues-management.

Related to [CAM-13620](https://jira.camunda.com/browse/CAM-13620).