### PR TITLE
chore(get-started): deprecate Nexus and add new artifact storage

### DIFF
--- a/get-started/content/apache-maven.md
+++ b/get-started/content/apache-maven.md
@@ -124,6 +124,10 @@ It is not needed when using `camunda-engine` because that already contains the D
 
 # Camunda Nexus
 
+{{< note title="Deprecation!" class="danger" >}}
+  Please note that, from 15th of October 2021, the Camunda Nexus is deprecated as we're migrating over to Artifactory as our new artifact storage.
+  Nevertheless, the settings still apply as we rewrite the URLs to the new location.
+{{< /note >}}
 ## Community Edition
 
 ```xml
@@ -181,6 +185,74 @@ This link helps you to browse the artifacts of Camunda Platform community editio
 This link helps you to browse the artifacts of Camunda Platform enterprise edition. The user needs to login to the nexus repository before accessing the link.
 
  https://app.camunda.com/nexus/service/rest/repository/browse/camunda-bpm-ee/
+
+{{< note title="Requires login" class="info" >}}
+   Please note that the link will not be accessible if the user didn't login beforehand.
+{{< /note >}}
+
+# Camunda Artifact Storage
+## Community Edition
+The config in the Camunda Nexus part about the [Community Edition]({{< relref "#community-edition-1" >}}) is still valid due to URL redirects.
+
+An alternative is to directly use the new URL of Artifactory.
+
+```xml
+<repositories>
+  <repository>
+    <id>camunda-bpm-nexus</id>
+    <name>camunda-bpm-nexus</name>
+    <url>
+      https://camunda.jfrog.io/artifactory/public/
+    </url>
+  </repository>
+</repositories>
+```
+
+
+## Enterprise Edition
+The config in the Camunda Nexus part about the [Enterprise Edition]({{< relref "#enterprise-edition-1" >}}) is still valid due to URL redirects.
+
+An alternative is to directly use the new URL of Artifactory.
+
+```xml
+<repositories>
+  <repository>
+    <id>camunda-bpm-nexus-ee</id>
+    <name>camunda-bpm-nexus</name>
+    <url>
+      https://camunda.jfrog.io/artifactory/camunda-bpm-ee
+    </url>
+  </repository>
+</repositories>
+```
+
+Using the Enterprise Edition repository requires credentials in your Maven settings `~/.m2/settings.xml`:
+```xml
+  <servers>
+    <server>
+      <id>camunda-bpm-nexus-ee</id>
+      <username>YOUR_USERNAME</username>
+      <password>YOUR_PASSWORD</password>
+    </server>
+  </servers>
+```
+
+## Browse Camunda Artifact Storage
+In order to browse the Camunda artifacts, here are the links which can be used.
+
+### Community Edition
+The mentioned link in the Camunda Nexus part about the [Community Edition]({{< relref "#community-edition-2" >}}) is still valid due to URL redirects.
+
+An alternative is to directly use the new URL of Artifactory.
+
+https://camunda.jfrog.io/ui/native/camunda-bpm
+
+### Enterprise Edition
+The mentioned link in the Camunda Nexus part about the [Enterprise Edition]({{< relref "#enterprise-edition-2" >}}) is still valid due to URL redirects.
+
+An alternative is to directly use the new URL of Artifactory.
+
+https://camunda.jfrog.io/ui/native/camunda-bpm-ee
 
 {{< note title="Requires login" class="info" >}}
    Please note that the link will not be accessible if the user didn't login beforehand.


### PR DESCRIPTION
due to URL redirects, the existing links are still valid and alternatives are provided

related to [INFRA-2706](https://jira.camunda.com/browse/INFRA-2706)

As the existing information is quite slim on Nexus, I added all relevant information for Artifactory to have a possible workaround URL but did not go deeper details on why/how/... due it it being customer facing.

The change can be tested by using the currently deployed proxy:
https://app.camunda.com/nexus2/

e.g.
https://app.camunda.com/nexus2/service/rest/repository/browse/camunda-bpm/
https://app.camunda.com/nexus/service/rest/repository/browse/camunda-bpm/
https://camunda.jfrog.io/ui/native/camunda-bpm/

To check the repository settings one could as an example run a basic maven app and use it in the pom / settings.xml
https://app.camunda.com/nexus2/content/groups/public
https://app.camunda.com/nexus/content/groups/public
https://camunda.jfrog.io/ui/native/public

example output from my test app: (using the internal group via proxy)
```
Downloading from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/org/camunda/bpm/camunda-database-settings/7.10.15-ee/camunda-database-settings-7.10.15-ee.pom
[WARNING] Could not validate integrity of download from https://app.camunda.com/nexus2/content/groups/internal/org/camunda/bpm/camunda-database-settings/7.10.15-ee/camunda-database-settings-7.10.15-ee.pom: Checksum validation failed, no checksums available
[WARNING] Checksum validation failed, no checksums available from camunda-nexus for https://app.camunda.com/nexus2/content/groups/internal/org/camunda/bpm/camunda-database-settings/7.10.15-ee/camunda-database-settings-7.10.15-ee.pom
Downloaded from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/org/camunda/bpm/camunda-database-settings/7.10.15-ee/camunda-database-settings-7.10.15-ee.pom (13 kB at 20 kB/s)
Downloading from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.pom
[WARNING] Could not validate integrity of download from https://app.camunda.com/nexus2/content/groups/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.pom: Checksum validation failed, no checksums available
[WARNING] Checksum validation failed, no checksums available from camunda-nexus for https://app.camunda.com/nexus2/content/groups/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.pom
Downloaded from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.pom (2.2 kB at 3.2 kB/s)
Downloading from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/junit/junit/4.11/junit-4.11.pom
Downloaded from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/junit/junit/4.11/junit-4.11.pom (2.3 kB at 8.1 kB/s)
Downloading from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom
Downloaded from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom (766 B at 4.7 kB/s)
Downloading from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.jar
[WARNING] Could not validate integrity of download from https://app.camunda.com/nexus2/content/groups/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.jar: Checksum validation failed, no checksums available
[WARNING] Checksum validation failed, no checksums available from camunda-nexus for https://app.camunda.com/nexus2/content/groups/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.jar
Downloaded from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.jar (3.3 kB at 8.5 kB/s)
Downloading from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/junit/junit/4.11/junit-4.11.jar
Downloaded from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/junit/junit/4.11/junit-4.11.jar (245 kB at 392 kB/s)
Downloading from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
Downloaded from camunda-nexus: https://app.camunda.com/nexus2/content/groups/internal/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar (45 kB at 153 kB/s)
```

using the artifactory url directly
```
Downloading from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/org/camunda/bpm/camunda-database-settings/7.10.15-ee/camunda-database-settings-7.10.15-ee.pom
[WARNING] Could not validate integrity of download from https://camunda.jfrog.io/artifactory/internal/org/camunda/bpm/camunda-database-settings/7.10.15-ee/camunda-database-settings-7.10.15-ee.pom: Checksum validation failed, no checksums available
[WARNING] Checksum validation failed, no checksums available from camunda-nexus for https://camunda.jfrog.io/artifactory/internal/org/camunda/bpm/camunda-database-settings/7.10.15-ee/camunda-database-settings-7.10.15-ee.pom
Downloaded from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/org/camunda/bpm/camunda-database-settings/7.10.15-ee/camunda-database-settings-7.10.15-ee.pom (13 kB at 18 kB/s)
Downloading from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.pom
[WARNING] Could not validate integrity of download from https://camunda.jfrog.io/artifactory/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.pom: Checksum validation failed, no checksums available
[WARNING] Checksum validation failed, no checksums available from camunda-nexus for https://camunda.jfrog.io/artifactory/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.pom
Downloaded from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.pom (2.2 kB at 5.5 kB/s)
Downloading from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/junit/junit/4.11/junit-4.11.pom
Downloaded from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/junit/junit/4.11/junit-4.11.pom (2.3 kB at 6.5 kB/s)
Downloading from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom
Downloaded from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom (766 B at 5.6 kB/s)
Downloading from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.jar
[WARNING] Could not validate integrity of download from https://camunda.jfrog.io/artifactory/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.jar: Checksum validation failed, no checksums available
[WARNING] Checksum validation failed, no checksums available from camunda-nexus for https://camunda.jfrog.io/artifactory/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.jar
Downloaded from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/org/camunda/community/infra/githubdemo/camunda-infra-githubdemo/2.0.0/camunda-infra-githubdemo-2.0.0.jar (3.3 kB at 12 kB/s)
Downloading from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/junit/junit/4.11/junit-4.11.jar
Downloaded from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/junit/junit/4.11/junit-4.11.jar (245 kB at 368 kB/s)
Downloading from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
Downloaded from camunda-nexus: https://camunda.jfrog.io/artifactory/internal/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar (45 kB at 238 kB/s)
```

The checksum warning you see shouldn't be an issue after the migration anymore as the latest migration tool version supports checkSum calc, which should solve it.