### PR TITLE
Release Announcements 7.20

### DIFF
--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -57,7 +57,7 @@ __Removed support for Modules:__
 
 * End of Support for Camunda RPA Bridge
 * End of Support for XSLT script engine
-* End of Support for Velocity. XQuey Script Engines
+* End of Support for Velocity. XQuery Script Engines
 * End of Support for Standalone Web Application Distribution
 Note that this does not affect previous Camunda versions, i.e. 7.19 and before.
 

--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -51,7 +51,6 @@ __Changes in Supported Environments:__
 * End of Support for JBoss Redhat EAP 7.2 / 7.3
 * End of Support for PostgreSQL 12 / 13
 * End of Support for Amazon Aurora PostgreSQL 12
-* End of Support for MariaDB 10.4
 * End of Support for Oracke 12c
 
 __Removed support for Modules:__

--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -35,6 +35,33 @@ __Camunda Platform 7 - Extended Maintenance Support (April 2027+*)__
 
 # Camunda Platform Announcements
 
+## Camunda Platform 7.20
+
+__Release Date:__ scheduled for 11th of October 2023
+
+__End of Maintenance:__ 8th of April 2025
+
+__Changes in Supported Environments:__
+
+* Support for SpringBoot 3.x
+* Support for Quarkus 3.x
+* End of Support for Java 8
+* End of Support for Quarkus 2.x
+* End of Support for Wildfly 14 - 25
+* End of Support for JBoss Redhat EAP 7.2 / 7.3
+* End of Support for PostgreSQL 12 / 13
+* End of Support for Amazon Aurora PostgreSQL
+* End of Support for MariaDB 10.4
+* End of Support for Oracke 12c
+
+__Removed support for Modules:__
+
+* End of Support for Camunda RPA Bridge
+* End of Support for XSLT script engine
+* End of Support for Velocity. XQuey Script Engines
+* End of Support for Standalone Web Application Distribution
+Note that this does not affect previous Camunda versions, i.e. 7.19 and before.
+
 ## Camunda Platform 7.19
 
 __Release Date:__ scheduled for 11th of April 2023

--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -37,7 +37,7 @@ __Camunda Platform 7 - Extended Maintenance Support (April 2027+*)__
 
 ## Camunda Platform 7.20
 
-__Release Date:__ scheduled for 11th of October 2023
+__Release Date:__ scheduled for 10th of October 2023
 
 __End of Maintenance:__ 8th of April 2025
 

--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -47,10 +47,10 @@ __Changes in Supported Environments:__
 * Support for Quarkus 3.x
 * End of Support for Java 8
 * End of Support for Quarkus 2.x
-* End of Support for Wildfly 14 - 25
+* End of Support for Wildfly 14 / 15 / 16 / 17 / 18 / 19 / 20 / 21 / 22 / 24 / 25
 * End of Support for JBoss Redhat EAP 7.2 / 7.3
 * End of Support for PostgreSQL 12 / 13
-* End of Support for Amazon Aurora PostgreSQL
+* End of Support for Amazon Aurora PostgreSQL 12
 * End of Support for MariaDB 10.4
 * End of Support for Oracke 12c
 

--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -57,7 +57,7 @@ __Removed support for Modules:__
 
 * End of Support for Camunda RPA Bridge
 * End of Support for XSLT script engine
-* End of Support for Velocity. XQuery Script Engines
+* End of Support for Velocity and XQuery Script Engines
 * End of Support for Standalone Web Application Distribution
 Note that this does not affect previous Camunda versions, i.e. 7.19 and before.
 

--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -51,7 +51,7 @@ __Changes in Supported Environments:__
 * End of Support for JBoss EAP 7.2 / 7.3
 * End of Support for PostgreSQL 12 / 13
 * End of Support for Amazon Aurora PostgreSQL 12
-* End of Support for Oracke 12c
+* End of Support for Oracle 12c
 
 __Removed support for Modules:__
 

--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -39,7 +39,7 @@ __Camunda Platform 7 - Extended Maintenance Support (April 2027+*)__
 
 __Release Date:__ scheduled for 10th of October 2023
 
-__End of Maintenance:__ 8th of April 2025
+__End of Maintenance:__ 9th of April 2025
 
 __Changes in Supported Environments:__
 
@@ -65,7 +65,7 @@ Note that this does not affect previous Camunda versions, i.e. 7.19 and before.
 
 __Release Date:__ scheduled for 11th of April 2023
 
-__End of Maintenance:__ 8th of October 2024
+__End of Maintenance:__ 9th of October 2024
 
 __Changes in Supported Environments:__
 

--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -47,7 +47,7 @@ __Changes in Supported Environments:__
 * Support for Quarkus 3.x
 * End of Support for Java 8
 * End of Support for Quarkus 2.x
-* End of Support for Wildfly 14 / 15 / 16 / 17 / 18 / 19 / 20 / 21 / 22 / 24 / 25
+* End of Support for WildFly 15 / 16 / 17 / 18 / 19 / 20 / 21 / 22 / 24 / 25
 * End of Support for JBoss Redhat EAP 7.2 / 7.3
 * End of Support for PostgreSQL 12 / 13
 * End of Support for Amazon Aurora PostgreSQL 12

--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -48,7 +48,7 @@ __Changes in Supported Environments:__
 * End of Support for Java 8
 * End of Support for Quarkus 2.x
 * End of Support for WildFly 15 / 16 / 17 / 18 / 19 / 20 / 21 / 22 / 24 / 25
-* End of Support for JBoss Redhat EAP 7.2 / 7.3
+* End of Support for JBoss EAP 7.2 / 7.3
 * End of Support for PostgreSQL 12 / 13
 * End of Support for Amazon Aurora PostgreSQL 12
 * End of Support for Oracke 12c


### PR DESCRIPTION
https://github.com/camunda/camunda-bpm-platform/issues/3243

- As we retire EAP 7.2. and 7.3 we can also retire Wildfly 15 and 18
- Amazon Postgres 12 used for Amazon Aurora Postgres 12,  is maintained until 11/2024. It is removed as 7.20 has to be maintained until April 2025.