### PR TITLE
fix(config): set exact match for the archived get-started guides

### DIFF
--- a/config/live/.htaccess
+++ b/config/live/.htaccess
@@ -573,7 +573,7 @@ RewriteRule ^get-started/cmmn11(.*) /manual/latest/reference/cmmn11/ [R=307,L]
 # Get Started
 RewriteRule ^(latest|7.3|7.2|7.1|7.0)/guides/getting-started-guides /get-started/ [R=301,L]
 RewriteRule ^guides/getting-started-guides /get-started/ [R=301,L]
-RewriteRule ^get-started/javaee6 /get-started/javaee7 [R=301,L]
+RewriteRule ^get-started/javaee6 /get-started/archive/javaee7 [R=301,L]
 RewriteRule ^get-started/bpmn20 /get-started/quick-start [R=301,L]
 RewriteRule ^get-started/javaee7$ /get-started/archive/javaee7 [R=301,L]
 RewriteRule ^get-started/spring$ /get-started/archive/spring [R=301,L]

--- a/config/live/.htaccess
+++ b/config/live/.htaccess
@@ -575,9 +575,9 @@ RewriteRule ^(latest|7.3|7.2|7.1|7.0)/guides/getting-started-guides /get-started
 RewriteRule ^guides/getting-started-guides /get-started/ [R=301,L]
 RewriteRule ^get-started/javaee6 /get-started/javaee7 [R=301,L]
 RewriteRule ^get-started/bpmn20 /get-started/quick-start [R=301,L]
-RewriteRule ^get-started/javaee7 /get-started/archive/javaee7 [R=301,L]
-RewriteRule ^get-started/spring /get-started/archive/spring [R=301,L]
-RewriteRule ^get-started/java-process-app /get-started/archive/java-process-app [R=301,L]
+RewriteRule ^get-started/javaee7$ /get-started/archive/javaee7 [R=301,L]
+RewriteRule ^get-started/spring$ /get-started/archive/spring [R=301,L]
+RewriteRule ^get-started/java-process-app$ /get-started/archive/java-process-app [R=301,L]
 
 # Manual (User Guide)
 RewriteRule ^(7.3|7.2|7.1|7.0)/api-references/javadoc/(.*) /javadoc/camunda-bpm-platform/$1/$2 [R=301,L]

--- a/config/stage/.htaccess
+++ b/config/stage/.htaccess
@@ -568,7 +568,7 @@ RewriteRule ^get-started/cmmn11(.*) /manual/latest/reference/cmmn11/ [R=307,L]
 # Get Started
 RewriteRule ^(latest|7.3|7.2|7.1|7.0)/guides/getting-started-guides /get-started/ [R=301,L]
 RewriteRule ^guides/getting-started-guides /get-started/ [R=301,L]
-RewriteRule ^get-started/javaee6 /get-started/javaee7 [R=301,L]
+RewriteRule ^get-started/javaee6 /get-started/archive/javaee7 [R=301,L]
 RewriteRule ^get-started/bpmn20 /get-started/quick-start [R=301,L]
 RewriteRule ^get-started/javaee7$ /get-started/archive/javaee7 [R=301,L]
 RewriteRule ^get-started/spring$ /get-started/archive/spring [R=301,L]

--- a/config/stage/.htaccess
+++ b/config/stage/.htaccess
@@ -570,9 +570,9 @@ RewriteRule ^(latest|7.3|7.2|7.1|7.0)/guides/getting-started-guides /get-started
 RewriteRule ^guides/getting-started-guides /get-started/ [R=301,L]
 RewriteRule ^get-started/javaee6 /get-started/javaee7 [R=301,L]
 RewriteRule ^get-started/bpmn20 /get-started/quick-start [R=301,L]
-RewriteRule ^get-started/javaee7 /get-started/archive/javaee7 [R=301,L]
-RewriteRule ^get-started/spring /get-started/archive/spring [R=301,L]
-RewriteRule ^get-started/java-process-app /get-started/archive/java-process-app [R=301,L]
+RewriteRule ^get-started/javaee7$ /get-started/archive/javaee7 [R=301,L]
+RewriteRule ^get-started/spring$ /get-started/archive/spring [R=301,L]
+RewriteRule ^get-started/java-process-app$ /get-started/archive/java-process-app [R=301,L]
 
 # Manual (User Guide)
 RewriteRule ^(7.3|7.2|7.1|7.0)/api-references/javadoc/(.*) /javadoc/camunda-bpm-platform/$1/$2 [R=301,L]


### PR DESCRIPTION
The current config redirects you from https://docs.camunda.org/get-started/spring-boot/ to https://docs.camunda.org/get-started/archive/spring/ which is unwanted behaviour

Follow up of #344 