### PR TITLE
fix(test): adjust target of get-started/javaee6

### DIFF
--- a/test/HttpRedirectionTest.yml
+++ b/test/HttpRedirectionTest.yml
@@ -54,7 +54,7 @@ https://stage.docs.camunda.org:
     target: /optimize/latest/
     status: 301
   /get-started/javaee6:
-    target: /get-started/javaee7
+    target: /get-started/archive/javaee7
     status: 301
   /get-started/cmmn10/project-setup:
     target: /get-started/cmmn11/project-setup


### PR DESCRIPTION
Follow up of #359, #344 
fixing failing test - https://ci.cambpm.camunda.cloud/job/docs/job/camunda-docs-smoke-test/4349/artifact/build/reports/tests/test/classes/org.camunda.docs.HttpRedirectionTest.html

```
testLocationHeader[16: {baseUrl=https://stage.docs.camunda.org, route=/get-started/javaee6, target=/get-started/javaee7, status=301})]
testLocationHeader[4: {baseUrl=https://docs.camunda.org, route=/get-started/javaee6, target=/get-started/javaee7, status=301})]
```