### PR TITLE
Add security notice 95 and change cawemo version on download page

### DIFF
--- a/enterprise/content/download.md
+++ b/enterprise/content/download.md
@@ -3761,11 +3761,11 @@ For installing the latter, please download one of the following archives and rea
   <tbody>
     <tr class="well">
       <td><a href="/cawemo">Cawemo On-Premises</a></td>
-      <td>1.9.9</td>
-      <td>01.08.2023</td>
+      <td>1.9.10</td>
+      <td>14.09.2023</td>
       <td>
-        <a class="btn btn-sm btn-default" href="https://docs.camunda.org/cawemo/1.9/download/cawemo-1.9.9.zip">zip</a>
-        <a class="btn btn-sm btn-default" href="https://docs.camunda.org/cawemo/1.9/download/cawemo-1.9.9.tar.gz">tar.gz</a>
+        <a class="btn btn-sm btn-default" href="https://docs.camunda.org/cawemo/1.9/download/cawemo-1.9.10.zip">zip</a>
+        <a class="btn btn-sm btn-default" href="https://docs.camunda.org/cawemo/1.9/download/cawemo-1.9.10.tar.gz">tar.gz</a>
       </td>
     </tr>
   </tbody>

--- a/security/content/notices.md
+++ b/security/content/notices.md
@@ -15,6 +15,32 @@ releases of the community platform.
 
 # Notices
 
+## Notice 95
+
+**Publication Date: September 14th, 2023**
+
+**Product affected:**
+
+Cawemo On-Premises
+
+**Impact:**
+
+The version of `libcrypto3` and `libssl3` shipped with `cawemo-restapi`, `cawemo-webapp` and `cawemo-websockets` were affected by the following vulnerability:
+- https://avd.aquasec.com/nvd/cve-2023-3817
+
+The version of `busybox`, `busybox-binsh` and `ssl_client` shipped with `cawemo-restapi` and `cawemo-websockets` were affected by the following vulnerability:
+- https://avd.aquasec.com/nvd/cve-2022-48174
+
+**How to determine if the installation is affected**
+
+- Cawemo On-Premises 1.9.9 or lower is used
+- See the NIST links above for detailed descriptions of the circumstances required to exploit the vulnerabilities
+
+**Solution**
+
+Camunda has provided 1.9.10 releases for the `cawemo-restapi`, `cawemo-webapp`, and `cawemo-websockets` Docker images
+which contain fixes for the above-mentioned CVEs.
+
 ## Notice 94
 
 **Publication Date: August 8th, 2023**


### PR DESCRIPTION
Relates to https://github.com/camunda/cawemo/issues/11417