### PR TITLE
chore(quick-start): Adjust JAXB Dependency

### DIFF
--- a/get-started/content/quick-start/service-task.md
+++ b/get-started/content/quick-start/service-task.md
@@ -140,11 +140,11 @@ Your pom.xml file of your project should look like this:
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.36</version>
 		</dependency>
-		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.3.1</version>
-		</dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.2</version>
+        </dependency>
 	</dependencies>
 </project>
 ```

--- a/get-started/content/quick-start/service-task.md
+++ b/get-started/content/quick-start/service-task.md
@@ -140,11 +140,11 @@ Your pom.xml file of your project should look like this:
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.36</version>
 		</dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>4.0.2</version>
-        </dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>4.0.2</version>
+		</dependency>
 	</dependencies>
 </project>
 ```


### PR DESCRIPTION
**Context**: Using the [example](https://docs.camunda.org/get-started/quick-start/service-task/#add-camunda-external-task-client-dependency) of documentation and starting the client results in a `ClassNotFoundException: jakarta.xml.bind.JAXBException`

The fix adjusts the jaxb dependency to use the same **jakarta** dependency as used in `camunda-bpm-platform`.

**Related-to**: https://github.com/camunda/camunda-bpm-platform/issues/4520