### PR TITLE
chore(download): add 7.22.0-alpha5 to download page

### DIFF
--- a/enterprise/content/download.md
+++ b/enterprise/content/download.md
@@ -79,6 +79,21 @@ downloads:
   branches:
     - branch: "7.22"
       releases:
+        - number: "7.22.0-alpha6"
+          note: "https://github.com/camunda/camunda-bpm-platform/issues?q=is%3Aissue+is%3Aclosed+reason%3A%22completed%22+label%3Aversion%3A7.22.0-alpha6"
+          date: "2024.09.23"
+          excludeservers:
+            - "wildfly"
+            - "wildfly11"
+            - "wildfly10"
+            - "wildfly8"
+            - "glassfish"
+            - "ibm-was"
+            - "ibm-was-85"
+            - "ibm-was9"
+            - "jboss"
+          excludeformats:
+            - "war"
         - number: "7.22.0-alpha5"
           note: "https://github.com/camunda/camunda-bpm-platform/issues?q=is%3Aissue+is%3Aclosed+reason%3A%22completed%22+label%3Aversion%3A7.22.0-alpha5"
           date: "2024.09.10"


### PR DESCRIPTION
Related-to: https://github.com/camunda/camunda-bpm-platform/issues/4592