### PR TITLE
Clarify end of support for container-managed only

### DIFF
--- a/enterprise/content/announcement.md
+++ b/enterprise/content/announcement.md
@@ -72,9 +72,9 @@ __Changes in Supported Environments:__
 * Support for PostgreSQL 17 (Support is also provided for Camunda 7.22 as a patch)
 * Support for Amazon Aurora PostgreSQL 16
 * Support for Spring Boot 3.4 (Support is also provided for Camunda 7.22 as a patch)
-* End of Support IBM WebSphere Liberty (Container-Managed Process Engine)
-* End of Support WildFly Application Server 23 + 26 (Container-Managed Process Engine)
-* End of Support Oracle Weblogic 14 (Container-Managed Process Engine)
+* End of Support IBM WebSphere Liberty (Container-Managed Process Engine and Camunda Webapps)
+* End of Support WildFly Application Server 23 + 26 (Container-Managed Process Engine and Camunda Webapps)
+* End of Support Oracle Weblogic 14 (Container-Managed Process Engine and Camunda Webapps)
 * End of Support Spring Boot 3.3
 * End of Support Amazon Aurora PostgreSQL 13
 


### PR DESCRIPTION
Discussed a misunderstanding with a customer. They are running an embedded, application-managed process engine on IBM WebSphere Liberty.

This is still supported.

Support Ticket for reference: https://jira.camunda.com/browse/SUPPORT-27460.

@toco-cam, maybe more changes are required for consistency?

What is your point of view? 